### PR TITLE
fix: Handle missing frames gracefully (print/delete)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ fn main() -> ExitCode {
                                 is_first_file_print = false;
                             }
                         }
-                        if let Err(e) = print_tag_frame_query(&tag, frame) {
+                        if let Err(e) = print_tag_frame_query(&tag, frame, fpath) {
                             eprintln!("rsid3: {e}");
                             return ExitCode::FAILURE;
                         }
@@ -150,9 +150,9 @@ fn main() -> ExitCode {
                         }
                     },
                     Action::Delete(frame) => {
-                        match delete_tag_frame(&mut tag, frame) {
-                            Ok(_) => {
-                                tag_was_modified = true;
+                        match delete_tag_frame(&mut tag, frame, fpath) {
+                            Ok(modified) => {
+                                tag_was_modified |= modified;
                             },
                             Err(e) => {
                                 eprintln!("rsid3: {e}");


### PR DESCRIPTION
Missing frames when the printing or deleting a frame no longer cause the entire program to terminate. Instead, the operation is simply skipped (when printing, the frame separator is still emitted, which effectively makes the result identical as if the frame existed and contained an empty string).

It is still possible to distinguish a "no frame" situation from an "empty frame", due to warnings that are printed on stderr whenever a print or delete cannot happen due to a missing frame.

Issue: #7