### PR TITLE
feat: Add -V/--version option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +88,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,12 +115,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rsid3"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "id3",
  "tempfile",
+ "vergen",
 ]
 
 [[package]]
@@ -122,6 +177,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "serde"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +223,57 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "vergen"
+version = "8.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "rustversion",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rsid3"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,3 +10,7 @@ edition = "2021"
 anyhow = "1.0.80"
 id3 = "1.12.0"
 tempfile = "3.10.1"
+
+[build-dependencies]
+anyhow = "1.0.80"
+vergen = { version = "8.3.1", features = ["build", "git", "gitcl"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use vergen::EmitBuilder;
+
+const RSID3_VERSION_MAJOR: u8 = 0;
+const RSID3_VERSION_MINOR: u8 = 1;
+const RSID3_VERSION_PATCH: u8 = 0;
+const RSID3_VERSION_STR: &str = "0.1.0";
+
+pub fn main() -> Result<()> {
+    // NOTE: This will output only a build timestamp and long SHA from git.
+    // NOTE: This set requires the build and git features.
+    // NOTE: See the EmitBuilder documentation for configuration options.
+    EmitBuilder::builder()
+        .build_timestamp()
+        .git_sha(false)
+        .emit()?;
+    println!("cargo::rustc-env=RSID3_VERSION_MAJOR={}", RSID3_VERSION_MAJOR);
+    println!("cargo::rustc-env=RSID3_VERSION_MINOR={}", RSID3_VERSION_MINOR);
+    println!("cargo::rustc-env=RSID3_VERSION_PATCH={}", RSID3_VERSION_PATCH);
+    println!("cargo::rustc-env=RSID3_VERSION_STR={}", RSID3_VERSION_STR);
+    Ok(())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use id3::frame::{Comment, Lyrics, ExtendedText, ExtendedLink};
 #[derive(Debug)]
 pub struct Cli {
     pub help: bool,
+    pub version: bool,
     pub list_frames: bool,
     pub frame_sep: Option<String>,
     pub file_sep: Option<String>,
@@ -56,6 +57,7 @@ impl Cli {
         println!();
         println!("Options:");
         println!("  -h, --help               Show this help and exit.");
+        println!("  -V, --version            Print version information.");
         println!("  -L, --list-frames        List all supported frames.");
         println!("  -d SEP, --frame-sep SEP  Separate printed frames with SEP (default: \\n).");
         println!("  -D SEP, --file-sep SEP   Separate printed files with SEP (default: \\n).");
@@ -93,6 +95,14 @@ impl Cli {
         println!("Convert options cannot be combined, as it wouldn't make sense. If no convert");
         println!("options are passed, rsid3 keeps the existing tag versions, or defaults to ID3v2.4");
         println!("when creating new tags from scratch.");
+    }
+
+    /// Prints the current version of rsid3.
+    pub fn print_version() {
+        println!("rsid3 {}-{}\nBuilt on {}",
+            env!("RSID3_VERSION_STR"),
+            env!("VERGEN_GIT_SHA").chars().take(8).collect::<String>(),
+            env!("VERGEN_BUILD_TIMESTAMP"));
     }
 
     /// Prints the available frames.
@@ -211,6 +221,7 @@ impl Cli {
     pub fn parse_args() -> Result<Self> {
         let args: Vec<String> = args().collect();
         let mut help = false;
+        let mut version = false;
         let mut list_frames = false;
         let mut frame_sep: Option<String> = None;
         let mut file_sep: Option<String> = None;
@@ -222,6 +233,7 @@ impl Cli {
             let arg = args[i].as_str();
             match arg {
                 "-h" | "--help" => { help = true; },
+                "-V" | "--version" => { version = true; },
                 "-L" | "--list-frames" => { list_frames = true; },
                 "-d" | "--frame-sep" => {
                     if i + 1 >= args.len() {
@@ -460,6 +472,7 @@ impl Cli {
 
         Ok(Cli {
             help,
+            version,
             list_frames,
             frame_sep,
             file_sep,

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,11 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
+    if cli.version {
+        Cli::print_version();
+        return ExitCode::SUCCESS;
+    }
+
     if cli.list_frames {
         Cli::print_all_frames();
         return ExitCode::SUCCESS;


### PR DESCRIPTION
Prints the current version, git SHA and build timestamp, kindly provided by the vergen crate.

Issue: #6